### PR TITLE
Поддержка изображений в системе сборки с latexmkmod

### DIFF
--- a/.latexmkmodrc
+++ b/.latexmkmodrc
@@ -55,7 +55,7 @@ sub my_help_print() {
         "                              (default is 'build')\n",
         "   -rcd, -rel-curdir <path> - set current directory path relative to build\n",
         "                              directory, for example ..\n",
-        "                              (absolute path is used by default\)n"
+        "                              (absolute path is used by default)\n"
 }
 
 my %exists_prog;

--- a/.latexmkmodrc
+++ b/.latexmkmodrc
@@ -3,14 +3,18 @@ use File::Which;
 use File::Copy;
 use Cwd;
 
-$current_dir = cwd();
-$tex_dir = "$current_dir/tex";
-$graphics_dir = "$current_dir/graphics";
-$other_img_dir = "$graphics_dir/img";
-$src_dir = "$current_dir/src";
+sub set_dirs {
+    $current_dir = $_[0];
+    $tex_dir = "$current_dir/tex";
+    $graphics_dir = "$current_dir/graphics";
+    $other_img_dir = "$graphics_dir/img";
+    $src_dir = "$current_dir/src";
+}
 
 $use_pdflatex = 0;
 $build_dir = "build";
+$cur_dir = cwd();
+set_dirs($cur_dir);
 
 sub my_option_handler {
     my ($type, $arg, $argv) = @_;
@@ -23,10 +27,19 @@ sub my_option_handler {
             $use_pdflatex = 1;
             return 0;
         } elsif ($arg eq '-build-dir' || $arg eq '-bd'){
-            if ($#$argv == -1){
+            if ($#$argv == -1 || @$argv[0] eq '--'){
                 die("Specify build directory after $arg!");
             }
             $build_dir = shift(@$argv);
+            return 0;
+        } elsif($arg eq '-rel-curdir' || $arg eq '-rcd'){
+            if ($#$argv == -1 || @$argv[0] eq '--'){
+                die("Specify current directory relative path after $arg!");
+            }
+            $cur_dir = shift(@$argv);
+            set_dirs($cur_dir);
+            return 0;
+        } elsif($arg eq '-'){
             return 0;
         }
     }
@@ -37,9 +50,12 @@ sub my_help_print() {
     print
         "\n",
         "Additional options:\n\n",,
-        "   -up, -use-pdflatex      - use PdfLaTeX instead of XeLaTeX\n",
-        "   -bd, -build-dir <path>  - change build directory\n",
-        "                             (default is 'build')\n"
+        "   -up, -use-pdflatex       - use PdfLaTeX instead of XeLaTeX\n",
+        "   -bd, -build-dir <path>   - change build directory\n",
+        "                              (default is 'build')\n",
+        "   -rcd, -rel-curdir <path> - set current directory path relative to build\n",
+        "                              directory, for example ..\n",
+        "                              (absolute path is used by default\)n"
 }
 
 my %exists_prog;
@@ -50,6 +66,12 @@ foreach $prog ('inkscape', 'dot', 'dia', 'pygmentize', 'iconv'){
 $pdflatex = '';
 
 sub do_after_options {
+    $ENV{TEXINPUTS} =
+        (defined($ENV{TEXINPUTS}) ? "$ENV{TEXINPUTS}$Config{path_sep}" : '').
+        "$tex_dir$Config{path_sep}";
+    $ENV{BIBINPUTS} =
+        (defined($ENV{BIBINPUTS}) ? "$ENV{BIBINPUTS}$Config{path_sep}" : '').
+        "$tex_dir$Config{path_sep}";
     make_path($build_dir);
     chdir($build_dir);
     $pdflatex =
@@ -59,13 +81,6 @@ sub do_after_options {
 }
 
 set_cus_option_handler('my_option_handler', 'my_help_print');
-
-$ENV{TEXINPUTS} =
-    (defined($ENV{TEXINPUTS}) ? "$ENV{TEXINPUTS}$Config{path_sep}" : '').
-    "$tex_dir$Config{path_sep}";
-$ENV{BIBINPUTS} =
-    (defined($ENV{BIBINPUTS}) ? "$ENV{BIBINPUTS}$Config{path_sep}" : '').
-    "$tex_dir$Config{path_sep}";
 
 $MSWin_back_slash = 0;
 $cleanup_includes_cusdep_generated = 1;

--- a/.latexmkmodrc
+++ b/.latexmkmodrc
@@ -6,6 +6,7 @@ use Cwd;
 $current_dir = cwd();
 $tex_dir = "$current_dir/tex";
 $graphics_dir = "$current_dir/graphics";
+$other_img_dir = "$graphics_dir/img";
 $src_dir = "$current_dir/src";
 
 $use_pdflatex = 0;
@@ -75,20 +76,40 @@ $recorder = 1;
 $file_inc_dir  = "inc";
 $file_graphics_dir = "$file_inc_dir";
 $file_src_dir = "$file_inc_dir/src";
+$file_other_img_dir = "$file_inc_dir/img";
 $error_basename = "$file_inc_dir/error";
+
+@other_img_ext = (
+   'png', 'pdf', 'jpg', 'mps', 'jpeg', 'jbig2', 'jb2',
+   'PNG', 'PDF', 'JPG', 'JPEG', 'JBIG2', 'JB2'
+);
 
 sub custom_transform_cus_dep {
     my ($name, $all) = @_;
     if ($all){
         if ($name =~ /^\Q$file_src_dir\E/) {
-            $name =~ s!^$file_src_dir!$src_dir!;
+            $name =~ s!^\Q$file_src_dir\E!$src_dir!;
+            return $name;
+        } elsif($name =~ /^\Q$file_other_img_dir\E/) {
+            $src_name = $name;
+            $name =~ s!^\Q$file_other_img_dir\E!$other_img_dir!;
+            foreach my $ext (@other_img_ext){
+                if($name =~ /$ext$/ && -f $name){
+                    return $name;
+                }
+                if(-f "$name.$ext"){
+                    $name = ["$name.$ext", "$src_name.$ext"];
+                    return $name;
+                }
+            }
+            return '';
         } else {
-            $name = '';
+            return '';
         }
     } else {
-        $name =~ s!^$file_graphics_dir!$graphics_dir!;
+        $name =~ s!^\Q$file_graphics_dir\E!$graphics_dir!;
+        return $name;
     }
-    return $name;
 }
 
 sub make_dir_for_file {
@@ -164,7 +185,7 @@ sub nlo2nls {
 #for source files
 sub all_cus_dep {
     make_dir_for_file($cusdep_dest);
-    if ($use_pdflatex){
+    if ($use_pdflatex && $cusdep_source =~ /^\Q$src_dir\E/){
         if($exists_prog{iconv}){
             exec_cmd(sprintf($iconv_cmd, $cusdep_source, $cusdep_dest));
         } else {

--- a/README.md
+++ b/README.md
@@ -251,21 +251,20 @@ docker run --volume /path/to/latex-g7-32/:/doc/ somename
 
 Минимальные требования: сам скрипт и TeX Live.
 
-Сначала нужно установить этот скрипт. На Linux достаточно скопировать файл `latexmkmod.pl` в utils/latexmkmod. На Windows:
-
- 1. Скопировать `latexmkmod.pl` в каталог `TEXMFLOCAL`\scripts. (C:\texlive\texmf-local\scripts, например) Команда `kpsewhich -var-value TEXMFLOCAL` показывает, что находится в переменной `TEXMFLOCAL`. Если в каталоге `TEXMFLOCAL` нет папки scripts, её нужно создать.
- 2. Скопировать файл runscript.exe в latexmkmod.exe в директории, где находятся исполняемые файлы TeX Live (C:\texlive\2016\bin\win32, она обычно содержится в `PATH`)
- 3. Запустить mktexlsr из той же директории от имени администратора.
+Сначала нужно установить этот скрипт. На Linux достаточно скопировать файл `latexmkmod.pl` в utils/latexmkmod. На Windows в дополнение к этому ещё нужно добавить в `PATH` интерпретатор Perl. Он обычно включён в TeX Live, может находиться, например, в C:\texlive\2017\tlpkg\tlperl\bin
 
 Для сборки выполнить либо `build.sh` (Linux), либо `build.bat` (Windows): создастся директория build и в ней будет PDF файл.
 
-Если в командной строке указать опцию `-bd mybuilddir`, то выходные файлы будут в директории mybuilddir. Если указана опция `-up`, то используется PdfLaTeX вместо XeLaTeX. Опции latexmk также доступны (например, `-c` убирает выходные файлы)
+Если в командной строке указать опцию `-bd mybuilddir`, то выходные файлы будут в директории mybuilddir. Если указана опция `-up`, то используется PdfLaTeX вместо XeLaTeX. Опция `-rcd ..` указывает относительный путь к текущей директории относительно директории с выходными файлами, полезно, если в Windows текущая директория содержит русские буквы.
+
+Опции latexmk также доступны (например, `-c` убирает выходные файлы)
 
 Если установлен только TeX Live, то вместо изображений dot, dia, svg отобразятся заглушки и листингов с кодом не будет. Чтобы появились изображения, нужно установить Graphviz, Dia и Inkscape.
 
 Чтобы появились листинги кода при использовании XeLaTeX, нужно дополнительно установить: Python 2 и Pygments (`pip install pygments`). Если используется PdfLaTeX, нужно установить iconv.
 
-Пути к исполняемым файлам всех программ должны быть в `PATH`, при необходимости нужно их добавить туда вручную. Пример содержимого этой переменной: `PATH=C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\texlive\2016\bin\win32;C:\Program Files\Graphviz2.38\bin;C:\Program Files\Dia\bin;C:\Program Files\Inkscape;C:\Python27\;C:\Python27\Scripts`.
+Пути к исполняемым файлам всех программ должны быть в `PATH`, при необходимости нужно их добавить туда вручную. Пример содержимого этой переменной:
+`C:\Python27\;C:\Python27\Scripts;C:\texlive\2017\tlpkg\tlperl\bin;C:\texlive\2017\bin\win32;C:\Program Files (x86)\GnuWin32\bin;C:\Program Files\Inkscape;C:\Program Files (x86)\Dia\bin;C:\Program Files (x86)\Graphviz2.38\bin;`
 
 ## Использование LyX
 Откройте `lyx/rpz.lyx` и редактируйте.

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,1 @@
-latexmkmod -r .latexmkmodrc rpz.tex %*
+perl utils/latexmkmod -r .latexmkmodrc rpz.tex %*

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,1 @@
-perl utils/latexmkmod -r .latexmkmodrc rpz.tex %*
+perl utils/latexmkmod -r .latexmkmodrc %* -- rpz.tex

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./utils/latexmkmod -r .latexmkmodrc rpz.tex "$@"
+./utils/latexmkmod -r .latexmkmodrc "$@" -- rpz.tex


### PR DESCRIPTION
Для этого пришлось внести изменения в [latexmkmod](https://github.com/dvarubla/latexmkmod). Также обнаружил, что при компиляции на Windows, если каталог содержит не ASCII символы, то XeLaTeX не сможет скомпилировать отчёт. Это можно исправить, если указывать относительный путь, а не абсолютный, добавил соответствующую опцию.