### PR TITLE
Makefile: исправлена конвертация изображений в PDF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ $(INC)/svg/%.pdf : $(SVG)/%.svg
 		$(PDFTRIMWHITE) $*-tmp.pdf $*.pdf && \
 		rm $*-tmp.pdf
 
-$(INC)/img/%.pdf: $(IMG)/*
+$(INC)/img/%.pdf: $(IMG)/%.*
 	mkdir -p $(INC)/img
 	convert $< -quality 100 $@
 


### PR DESCRIPTION
В предыдущем варианте при нахождении нескольких файлов в каталоге graphics/img в каталоге tex/img оказывалось одно и тоже изображение во всех PDF файлах (при этом имена файлов были верными)

При вызове make выполнялись такие команды для всех файлов:

convert graphics/img/A.png -quality 100 tex/inc/img/A.pdf
convert graphics/img/A.png -quality 100 tex/inc/img/B.pdf
convert graphics/img/A.png -quality 100 tex/inc/img/C.pdf

и т.д.