### PR TITLE
Проценты в URL в списке литературы

### DIFF
--- a/tex/G2-105.sty
+++ b/tex/G2-105.sty
@@ -997,6 +997,9 @@
 \makeatother
 }
 
+% Проценты в URL в библиографии
+\def\BibUrl{\url}
+
 \newcommand\AfterHyperrefFix{% issue #31 fix (https://github.com/latex-g7-32/latex-g7-32/issues/31) 
  \makeatletter
  \let\Gost@old@sect\@sect

--- a/tex/rpz.bib
+++ b/tex/rpz.bib
@@ -9,3 +9,12 @@
   language =     "russian"
 }
 
+@online{wiki:latex,
+  author = {Wikipedia},
+  title = {Типографика "--- Википедия},
+  year = {2012},
+  url = {https://ru.wikipedia.org/wiki/%D0%A2%D0%B8%D0%BF%D0%BE%D0%B3%D1%80%D0%B0%D1%84%D0%B8%D0%BA%D0%B0},
+  urldate = {25.01.2012},
+  language =     "russian"
+}
+


### PR DESCRIPTION
Столкнулся с неприятным багом — проценты в URL в библиографии (например, если скопировать URL из википедии) вызывают ошибку. Причина вроде бы заключается в неправильном макросе `\BibUrl` (`\providecommand*{\BibUrl}[1]{\url{#1}}` в rpz.bbl) 