### PR TITLE
Поддержка SyncTeX

### DIFF
--- a/.latexmkmodrc
+++ b/.latexmkmodrc
@@ -76,7 +76,7 @@ sub do_after_options {
     chdir($build_dir);
     $pdflatex =
         (($use_pdflatex) ? "pdflatex": "xelatex").
-        " -interaction=nonstopmode -shell-escape %O ".
+        " -synctex=1 -interaction=nonstopmode -shell-escape %O ".
         (($exists_prog{pygmentize})?"%S":"\"\\def\\NoMinted{}\\input{%S}\"");
 }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(PREFER_XELATEX)
         require_program(XELATEX_COMPILER xelatex)
     endif()
     set(USED_LATEX_COMPILER
-        "${XELATEX_COMPILER}" -interaction=nonstopmode -shell-escape)
+        "${XELATEX_COMPILER}" -synctex=1 -interaction=nonstopmode -shell-escape)
 else()
     set(USED_LATEX_COMPILER "${PDFLATEX_COMPILER}")
     require_program(ICONV_COMMAND iconv)


### PR DESCRIPTION
Наверное, все уже сами добавили себе эту полезную опцию в системы сборки. Позволяет с помощью Ctrl+ЛКМ по документу в нормальной IDE (например, TeXstudio) переходить в соответствующее место соответствующего .tex файла. Только вот для CMake нужно указать директорию с PDF файлом не build, а build/mirror/tex в настройках.